### PR TITLE
refactor: Move api base url to environment definition instead of hardcoding it

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -97,3 +97,5 @@ linter:
     library_private_types_in_public_api: false
 
     discarded_futures: false
+
+    do_not_use_environment: false

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -54,6 +55,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,10 @@ Future<void> main() async {
   SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.dark);
   await Firebase.initializeApp();
   final packageInfo = await PackageInfo.fromPlatform();
-  AppConfig(version: packageInfo.version, baseHttpUrl: 'http://10.0.2.2:8000');
+  AppConfig(
+    version: packageInfo.version,
+    baseHttpUrl: const String.fromEnvironment('API_BASE_URL'),
+  );
   await configureDependencies();
   AppBlocObserver.init();
   runApp(const Application());


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

<!-- Delete the statuses that don't apply -->

**READY**

## Breaking Changes
<!-- Delete the statuses that don't apply -->
 NO

## Description
<!--- Describe your changes in detail -->
This PR is for changing how the base api url gets loaded in the app. Instead of hardcoding it in the code it not accepts and environment variable named `API_BASE_URL` on build time. 

## Related Issues

<!-- Attach list of issues related to this PR here -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Test
